### PR TITLE
bugfix and support for hdr output

### DIFF
--- a/include/DirectionalLight.hpp
+++ b/include/DirectionalLight.hpp
@@ -12,6 +12,7 @@ class DirectionalLight : public Light {
 
   Color evaluate(const Vector3f& position) const override;
   Ray getShadowRay(const Vector3f& position, float& maxT) const override;
+  bool isDelta() const override { return true; };
 
   Color sampleLe(Vector3f&, SurfaceInfo&, RNG&, float&) const override { return {}; }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,3 @@
-#include <chrono>
-#include <fstream>
 #include <memory>
 
 #include "AreaLight.hpp"
@@ -102,7 +100,7 @@ int main() {
 
   std::cout << "Finished rendering in " << watch.getElapsedTime();
 
-  render.save("render.png");
+  render.save("render.hdr");
 
   return 0;
 }


### PR DESCRIPTION
Fixed bug with `DirectionalLight` (missing function implementation from `Light` base class) and added support for .hdr output. Appropriate stb function will get called, based on provided ouptut file extension (.png or .hdr). 