### PR TITLE
option to seed random number generator

### DIFF
--- a/include/RenderParameters.hpp
+++ b/include/RenderParameters.hpp
@@ -3,6 +3,7 @@
 
 #include <iostream>
 #include <thread>
+#include <optional>
 
 struct RenderParameters {
   unsigned int width = 1920;
@@ -11,6 +12,7 @@ struct RenderParameters {
   unsigned int threads = std::thread::hardware_concurrency();
   unsigned int mcSamples = 256;
   unsigned int saveFrequency = 10;
+  std::optional<unsigned int> seed = {};
   bool saveIntermediate = false;
 
   friend std::ostream& operator<<(std::ostream& os, const RenderParameters& params) {
@@ -19,6 +21,7 @@ struct RenderParameters {
     os << "Number of tiles: " << params.numTiles << "\n";
     os << "CPU Threads used: " << params.threads << "\n";
     os << "Save intermediate results: " << std::boolalpha << params.saveIntermediate << "\n";
+    os << "Seed: " << (params.seed.has_value() ? std::to_string(params.seed.value()) : "(not provided)") << "\n";
     os << "Intermediate results save frequency: " << params.saveFrequency << "\n";
     
     return os;

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -17,7 +17,11 @@
 #include "ThreadPool.hpp"
 
 Renderer::Renderer(const RenderParameters& parameters, std::shared_ptr<Integrator> integrator)
-    : parameters_(parameters), integrator_(integrator), rng_() {}
+    : parameters_(parameters), integrator_(integrator), rng_() {
+  if (parameters.seed.has_value()) {
+    rng_ = RNG(parameters.seed.value());
+  }
+}
 
 Image Renderer::render(std::unique_ptr<Camera> camera, const Scene& scene) const {
   Image result{parameters_.width, parameters_.height};

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -29,6 +29,7 @@ int main() {
   parameters.numTiles = 200;
   parameters.threads = 8;
   parameters.mcSamples = 64;
+  parameters.seed = 42;
   parameters.saveIntermediate = false;
 
   auto integrator = std::make_shared<PathTracer>();


### PR DESCRIPTION
Added option to seed random number generator. If no seed is provided, time-based seed will be used.

Verified that renders are binary identical on two consecutive runs, when seed is the same.