### PR TITLE
add exposure and reinhard tone mappers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,9 @@ set(PROJECT_CODE
   include/Cylinder.hpp
   include/Cone.hpp
   include/Paraboloid.hpp
+  include/ToneMapper.hpp
+  include/ExposureMapper.hpp src/ExposureMapper.cpp
+  include/ReinhardMapper.hpp src/ReinhardMapper.cpp
   include/Integrator.hpp src/Integrator.cpp
   include/PathTracer.hpp src/PathTracer.cpp
   include/DirectLighting.hpp src/DirectLighting.cpp

--- a/include/ExposureMapper.hpp
+++ b/include/ExposureMapper.hpp
@@ -1,0 +1,16 @@
+#ifndef EXPOSURE_MAPPER_HPP
+#define EXPOSURE_MAPPER_HPP
+
+#include "ToneMapper.hpp"
+
+class ExposureMapper : public ToneMapper {
+ public:
+  ExposureMapper(float exposure);
+
+  Image apply(const Image&) const override;
+
+ private:
+  float gain_;
+};
+
+#endif  // EXPOSURE_MAPPER

--- a/include/ExposureMapper.hpp
+++ b/include/ExposureMapper.hpp
@@ -13,4 +13,4 @@ class ExposureMapper : public ToneMapper {
   float gain_;
 };
 
-#endif  // EXPOSURE_MAPPER
+#endif  // EXPOSURE_MAPPER_HPP

--- a/include/ReinhardMapper.hpp
+++ b/include/ReinhardMapper.hpp
@@ -1,0 +1,26 @@
+#ifndef REINHARD_MAPPER_HPP
+#define REINHARD_MAPPER_HPP
+
+#include <optional>
+
+#include "Color.hpp"
+#include "Math.hpp"
+#include "ToneMapper.hpp"
+
+class ReinhardMapper : public ToneMapper {
+ public:
+  ReinhardMapper(float keyValue = 0.18f, bool useLWhite = false, std::optional<float> Lwhite = {})
+      : keyValue_(keyValue), useLWhite_(useLWhite), Lwhite_(Lwhite) {}
+
+  Image apply(const Image& input) const override;
+
+ private:
+  static Vector3f RGBToXYZ(const Color& color);
+  static Color XYZToRGB(const Vector3f& color);
+
+  float keyValue_;
+  bool useLWhite_;
+  std::optional<float> Lwhite_;
+};
+
+#endif  // REINHARD_MAPPER_HPP

--- a/include/Renderer.hpp
+++ b/include/Renderer.hpp
@@ -7,6 +7,7 @@
 #include "ImageTile.hpp"
 #include "RNG.hpp"
 #include "RenderParameters.hpp"
+#include "ToneMapper.hpp"
 
 class Ray;
 class Camera;
@@ -15,6 +16,8 @@ class Integrator;
 
 class Renderer {
  public:
+  Renderer(const RenderParameters& parameters, std::shared_ptr<Integrator> integrator,
+           std::unique_ptr<ToneMapper> toneMapper);
   Renderer(const RenderParameters& parameters, std::shared_ptr<Integrator> integrator);
 
   Image render(std::unique_ptr<Camera> camera, const Scene& scene) const;
@@ -22,6 +25,7 @@ class Renderer {
  private:
   RenderParameters parameters_;
   std::shared_ptr<Integrator> integrator_;
+  std::unique_ptr<ToneMapper> toneMapper_;
   mutable RNG rng_;
 };
 

--- a/include/ToneMapper.hpp
+++ b/include/ToneMapper.hpp
@@ -1,5 +1,5 @@
-#ifndef TONE_MAPPER_H
-#define TONE_MAPPER_H
+#ifndef TONE_MAPPER_HPP
+#define TONE_MAPPER_HPP
 
 class Image;
 
@@ -9,4 +9,4 @@ class ToneMapper {
   virtual Image apply(const Image&) const = 0;
 };
 
-#endif  // TONE_MAPPER_H
+#endif  // TONE_MAPPER_HPP

--- a/include/ToneMapper.hpp
+++ b/include/ToneMapper.hpp
@@ -1,0 +1,12 @@
+#ifndef TONE_MAPPER_H
+#define TONE_MAPPER_H
+
+class Image;
+
+class ToneMapper {
+ public:
+  virtual ~ToneMapper() = default;
+  virtual Image apply(const Image&) const = 0;
+};
+
+#endif  // TONE_MAPPER_H

--- a/src/ExposureMapper.cpp
+++ b/src/ExposureMapper.cpp
@@ -1,0 +1,20 @@
+#include "ExposureMapper.hpp"
+
+#include "Image.hpp"
+#include "Math.hpp"
+
+ExposureMapper::ExposureMapper(float exposure) : gain_(std::exp2f(exposure)) {}
+
+Image ExposureMapper::apply(const Image& input) const {
+  Image output = input;
+
+  for (unsigned int y = 0; y < input.getHeight(); ++y) {
+    for (unsigned int x = 0; x < input.getWidth(); ++x) {
+      const auto sourceValue = input.getPixel(x, y);
+      const auto newValue = sourceValue * gain_;
+      output.setPixel(x, y, newValue);
+    }
+  }
+
+  return output;
+}

--- a/src/ReinhardMapper.cpp
+++ b/src/ReinhardMapper.cpp
@@ -1,0 +1,79 @@
+#include "ReinhardMapper.hpp"
+
+#include "Image.hpp"
+
+Vector3f ReinhardMapper::RGBToXYZ(const Color& color) {
+  Vector3f result;
+
+  result.x = 0.4124f * color.r + 0.3576f * color.g + 0.1805f * color.b;
+  result.y = 0.2126f * color.r + 0.7152f * color.g + 0.0722f * color.b;
+  result.z = 0.0193f * color.r + 0.1192f * color.g + 0.9505f * color.b;
+
+  return result;
+}
+
+Color ReinhardMapper::XYZToRGB(const Vector3f& color) {
+  Color result;
+
+  result.r = 3.2406f * color.x - 1.5372f * color.y - 0.4986f * color.z;
+  result.g = -0.9689f * color.x + 1.8758f * color.y + 0.0415f * color.z;
+  result.b = 0.0557f * color.x - 0.2040f * color.y + 1.0570f * color.z;
+
+  return result;
+}
+
+Image ReinhardMapper::apply(const Image& input) const {
+  Image imageXYZ = input;
+
+  const auto N = input.getWidth() * input.getHeight();
+  float Lavg = 0.0f;
+  float Lmax = 0.0f;
+
+  for (unsigned int y = 0; y < input.getHeight(); ++y) {
+    for (unsigned int x = 0; x < input.getWidth(); ++x) {
+      const auto colorRGB = input.getPixel(x, y);
+      auto colorXYZ = RGBToXYZ(colorRGB);
+
+      const auto L = colorXYZ.y;
+      Lmax = std::max(Lmax, L);
+      Lavg += std::log(L + 0.00001f);
+
+      // Convert to xyY
+      const auto factor = 1.0f / (colorXYZ.x + colorXYZ.y + colorXYZ.z);
+      colorXYZ *= factor;
+      colorXYZ.z = L;
+
+      imageXYZ.setPixel(x, y, Color(colorXYZ.x, colorXYZ.y, colorXYZ.z));
+    }
+  }
+
+  Lavg = std::exp(Lavg / N);
+
+  const float Lwhite = Lwhite_.value_or(Lmax);
+
+  Image output = input;
+
+  for (unsigned int y = 0; y < input.getHeight(); ++y) {
+    for (unsigned int x = 0; x < input.getWidth(); ++x) {
+      const auto colorXYZ = imageXYZ.getPixel(x, y);
+      const auto L = colorXYZ.b * keyValue_ / Lavg;
+
+      float Lfinal = 1.0f;
+
+      if (useLWhite_) {
+        Lfinal = (L * (1.0f + L / (Lwhite * Lwhite))) / (1.0f + L);
+      } else {
+        Lfinal = L / (1.0f + L);
+      }
+
+      const float X = Lfinal / colorXYZ.g * colorXYZ.r;
+      const float Y = Lfinal;
+      const float Z = Lfinal / colorXYZ.g * (1.0f - colorXYZ.r - colorXYZ.g);
+
+      const auto colorRemapped = XYZToRGB(Vector3f(X, Y, Z));
+      output.setPixel(x, y, colorRemapped);
+    }
+  }
+
+  return output;
+}


### PR DESCRIPTION
Added support for tone mapping and implemented two tone mappers: Exposure and Reinhard.

Exposure tone mapper takes one argument, which is `exposure` and uses it to calculate gain, which multiplies values of the image:

$$
\text{gain} = 2^{\text{exposure}}
$$

$$
L_{\text{mapped}} = L_{\text{input}} \cdot \text{gain}
$$

Reinhard tone mapper has 3 parameters: `key` - corresponds to the gray level, `useLWhite` - tells if more sophisticated mapping function that involves reference white level should be used or the simplified one (L / (1 + L)), `Lwhite` - reference white point, if not provided `LMax` will be calculated and used.

Intermediate render will be tone mapped too.

If no tone mapper is used, colors will be just clipped. 