### PR TITLE
optimize direct lighting for brdf w/ delta dist.

### DIFF
--- a/src/DebugIntegrator.cpp
+++ b/src/DebugIntegrator.cpp
@@ -32,7 +32,7 @@ Color DebugIntegrator::integrate(const Ray& cameraRay, const Scene& scene, RNG&)
       const Vector3t color = (normal + Vector3t(1.0, 1.0, 1.0)) * 0.5;
       return Color{color.x, color.y, color.z};
     } else if (outputType_ == OutputType::Depth) {
-      return Color{1.0, 1.0, 1.0} * position.z;
+      return Color{1.0} * position.z;
     }
   }
 

--- a/src/DirectLighting.cpp
+++ b/src/DirectLighting.cpp
@@ -37,11 +37,15 @@ Color DirectLighting::integrate(const Ray& cameraRay, const Scene& scene, RNG& r
       const auto albedo = material.getAlbedo(uv);
       const auto wo = -ray.getDirection();
 
-      const auto directLighting =
-          computeDirectLighting(scene, position, wo, surfaceInfo, material, rng);
-      result += coeff * directLighting;
+      const auto isSpecular = brdf.getType() == BRDF::Type::PerfectSpecular;
 
-      if (brdf.getType() == BRDF::Type::PerfectSpecular) {
+      if (!isSpecular) {
+        const auto directLighting =
+            computeDirectLighting(scene, position, wo, surfaceInfo, material, rng);
+        result += coeff * directLighting;
+      }
+
+      if (isSpecular) {
         Vector3t tangent, bitangent;
         createOrthogonalFrame(normal, tangent, bitangent);
         const auto woShading = transformFromTangentSpace(wo, normal, tangent, bitangent);

--- a/src/PathTracer.cpp
+++ b/src/PathTracer.cpp
@@ -37,9 +37,13 @@ Color PathTracer::integrate(const Ray& cameraRay, const Scene& scene, RNG& rng) 
       const auto albedo = material.getAlbedo(uv);
       const auto wo = -ray.getDirection();
 
-      const auto directLighting =
-          computeDirectLighting(scene, position, wo, surfaceInfo, material, rng);
-      result += coeff * directLighting;
+      raySpecular = brdf.getType() == BRDF::Type::PerfectSpecular;
+
+      if (!raySpecular) {
+        const auto directLighting =
+            computeDirectLighting(scene, position, wo, surfaceInfo, material, rng);
+        result += coeff * directLighting;
+      }
 
       Vector3t tangent, bitangent;
       createOrthogonalFrame(normal, tangent, bitangent);
@@ -51,7 +55,6 @@ Color PathTracer::integrate(const Ray& cameraRay, const Scene& scene, RNG& rng) 
       const Float coswi = std::max(sample.y, static_cast<Float>(0.0));  // wi . (0, 1, 0)
 
       coeff *= albedo * f * coswi / pdf;
-      raySpecular = brdf.getType() == BRDF::Type::PerfectSpecular;
 
       Vector3t wi = transformToTangentSpace(sample, normal, tangent, bitangent).normalized();
       ray = Ray{position + wi * 0.001, wi};


### PR DESCRIPTION
These is no point in sampling lights when BRDF has a delta distribution (perfectly specular) because probability of sampling position that would yield non-zero contribution is zero - for such BRDFs only explicit ray construction works. 